### PR TITLE
Replace ${year} etc. variables in properties.

### DIFF
--- a/src/main/java/com/collective/celos/OozieExternalService.java
+++ b/src/main/java/com/collective/celos/OozieExternalService.java
@@ -48,13 +48,23 @@ public class OozieExternalService implements ExternalService {
     }
 
     Properties setupRunProperties(Properties defaults, ScheduledTime t) {
-        Properties runProperties = new Properties(defaults);
+        Properties runProperties = setupDefaultProperties(defaults, t);
         ScheduledTimeFormatter formatter = new ScheduledTimeFormatter();
         runProperties.setProperty(YEAR_PROP, formatter.formatYear(t));
         runProperties.setProperty(MONTH_PROP, formatter.formatMonth(t));
         runProperties.setProperty(DAY_PROP, formatter.formatDay(t));
         runProperties.setProperty(HOUR_PROP, formatter.formatHour(t));
         return runProperties;
+    }
+
+    private Properties setupDefaultProperties(Properties defaults, ScheduledTime t) {
+        Properties props = new Properties();
+        ScheduledTimeFormatter formatter = new ScheduledTimeFormatter();
+        for (String name : defaults.stringPropertyNames()) {
+            String value = defaults.getProperty(name);
+            props.setProperty(name, formatter.replaceTimeTokens(value, t));
+        }
+        return props;
     }
 
     @Override

--- a/src/test/java/com/collective/celos/OozieExternalServiceTest.java
+++ b/src/test/java/com/collective/celos/OozieExternalServiceTest.java
@@ -17,9 +17,11 @@ public class OozieExternalServiceTest {
     public void runPropertiesAreCorrectlySetup() {
         Properties defaults = new Properties();
         defaults.setProperty("foo", "bar");
+        defaults.setProperty("uses-variables", "${year}-${month}-${day}-${hour}-${year}");
         ScheduledTime t = new ScheduledTime("2013-11-26T17:00Z");
         Properties runProperties = makeOozieExternalService().setupRunProperties(defaults, t);
         Assert.assertEquals("bar", runProperties.getProperty("foo"));
+        Assert.assertEquals("2013-11-26-17-2013", runProperties.getProperty("uses-variables"));
         Assert.assertEquals("2013", runProperties.getProperty(OozieExternalService.YEAR_PROP));
         Assert.assertEquals("11", runProperties.getProperty(OozieExternalService.MONTH_PROP));
         Assert.assertEquals("26", runProperties.getProperty(OozieExternalService.DAY_PROP));


### PR DESCRIPTION
Simple solution for now: keep the single `"properties"` element and replace `${year}` etc in `OozieExternalService`.

collectivemedia/tracker#36
@collectivemedia/syn-datapipe2
