### PR TITLE
Add "fs" property to HDFSCheckTrigger specifying the filesystem to use.

### DIFF
--- a/src/main/java/com/collective/celos/HDFSCheckTrigger.java
+++ b/src/main/java/com/collective/celos/HDFSCheckTrigger.java
@@ -7,65 +7,34 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-/*
+/**
  * Check in HDFS for a data dependency.
  */
 public class HDFSCheckTrigger implements Trigger {
 
     public static final String PATH_PROP = "path";
+    public static final String FS_PROP = "fs";
 
-    /*
-     * This object knows how to replace the date/time tokens in the path.
-     */
     private final ScheduledTimeFormatter formatter = new ScheduledTimeFormatter();
-
+    private final FileSystem fs;
     private final String rawPathString;
 
-    public HDFSCheckTrigger(Properties properties) {
+    public HDFSCheckTrigger(Properties properties) throws Exception {
         this.rawPathString = properties.getProperty(PATH_PROP);
         if (this.rawPathString == null) {
             throw new IllegalArgumentException(PATH_PROP + " property not set.");
         }
+        String fsString = properties.getProperty(FS_PROP);
+        if (fsString == null) {
+            throw new IllegalArgumentException(FS_PROP + " property not set.");
+        }
+        this.fs = FileSystem.get(new URI(fsString), new Configuration());
     }
     
     @Override
     public boolean isDataAvailable(ScheduledTime t) throws Exception {
-
-        String cookedPathString = formatter.replaceTimeTokens(
-                rawPathString, t);
-
-        /*
-         * We use unqualified paths for our triggers (that is, they don't
-         * specify the scheme of "hdfs"). 
-         * 
-         * For reasons I don't fully understand, this code treats these
-         * paths slightly differently depending on some run-time setting:
-         * 
-         * 1) In unit tests on a dev box and oj01, an unqualified path is
-         * treated as a local file.  That is, "fs" is an instance of
-         * LocalFileSystem.
-         * 
-         * 2) When run using "java" or "hadoop jar" on a dev box, the same
-         * is true.
-         * 
-         * 3) But, when run using "java" or "hadoop jar" on oj01, fs is in
-         * instance of DistributedFileSystem.
-         * 
-         * So, unit test are written to set up and test the local file
-         * system.  Celos itself can also be run locally, accessing the
-         * local file system.  But when run on oj01 (the likely deployment
-         * platform) this code will access paths from HDFS.
-         * 
-         * NOTE: this is the approach that Sibyl has been using since it
-         * was first deployed.
-         */
-        Configuration conf = new Configuration();
-        FileSystem fs = FileSystem.get(URI.create(cookedPathString), conf);
-        
-        Path path = new Path(cookedPathString);
-        boolean result = fs.exists(path);
-        
-        return result;
+        Path path = new Path(formatter.replaceTimeTokens(rawPathString, t));
+        return fs.exists(path);
     }
 
 }

--- a/src/test/java/com/collective/celos/HDFSCheckTriggerTest.java
+++ b/src/test/java/com/collective/celos/HDFSCheckTriggerTest.java
@@ -24,6 +24,7 @@ public class HDFSCheckTriggerTest {
     public void testDirectoryExists() throws Exception {
         Properties props = new Properties();
         props.setProperty(HDFSCheckTrigger.PATH_PROP, "/tmp");
+        props.setProperty(HDFSCheckTrigger.FS_PROP, "file:///");
         assertTrue(new HDFSCheckTrigger(props).isDataAvailable(new ScheduledTime("2013-11-22T15:00Z")));
     }
 
@@ -31,6 +32,7 @@ public class HDFSCheckTriggerTest {
     public void testDirectoryDoesNotExist() throws Exception {
         Properties props = new Properties();
         props.setProperty(HDFSCheckTrigger.PATH_PROP, "/tmp-does-not-exist");
+        props.setProperty(HDFSCheckTrigger.FS_PROP, "file:///");
         assertFalse(new HDFSCheckTrigger(props).isDataAvailable(new ScheduledTime("2013-11-22T15:00Z")));
     }
 
@@ -44,7 +46,8 @@ public class HDFSCheckTriggerTest {
        
         Properties props = new Properties();
         props.setProperty(HDFSCheckTrigger.PATH_PROP, root + "/${year}-${month}-${day}/${hour}00/_READY");
-        
+        props.setProperty(HDFSCheckTrigger.FS_PROP, "file:///");
+
         assertTrue(new HDFSCheckTrigger(props).isDataAvailable(new ScheduledTime("2013-11-22T15:00Z")));
     }
 
@@ -59,7 +62,8 @@ public class HDFSCheckTriggerTest {
        
         Properties props = new Properties();
         props.setProperty(HDFSCheckTrigger.PATH_PROP, root + "/${year}-${month}-${day}/${hour}00/_READY");
-        
+        props.setProperty(HDFSCheckTrigger.FS_PROP, "file:///");
+
         assertFalse(new HDFSCheckTrigger(props).isDataAvailable(new ScheduledTime("2013-11-22T15:00Z")));
     }
     
@@ -71,7 +75,8 @@ public class HDFSCheckTriggerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testIOExceptionIsPropagated() throws Exception {
         Properties props = new Properties();
-        props.setProperty(HDFSCheckTrigger.PATH_PROP, "hdfs://no-such-host/some/path");
+        props.setProperty(HDFSCheckTrigger.PATH_PROP, "/some/path");
+        props.setProperty(HDFSCheckTrigger.FS_PROP, "hdfs://no-such-host");
         new HDFSCheckTrigger(props).isDataAvailable(new ScheduledTime("2013-11-22T15:00Z"));
     }
 

--- a/src/test/resources/com/collective/celos/workflow-configuration-test/json-workflow-list-servlet-test/workflow-1.json
+++ b/src/test/resources/com/collective/celos/workflow-configuration-test/json-workflow-list-servlet-test/workflow-1.json
@@ -13,7 +13,8 @@
     "trigger": {
         "type": "com.collective.celos.HDFSCheckTrigger",
         "properties": {
-            "path": "foo"
+            "path": "foo",
+            "fs": "file:///"
         }
     },
     "externalService": {

--- a/src/test/resources/com/collective/celos/workflow-configuration-test/json-workflow-list-servlet-test/workflow-2.json
+++ b/src/test/resources/com/collective/celos/workflow-configuration-test/json-workflow-list-servlet-test/workflow-2.json
@@ -13,7 +13,8 @@
     "trigger": {
         "type": "com.collective.celos.HDFSCheckTrigger",
         "properties": {
-            "path": "foo"
+            "path": "foo",
+            "fs": "file:///"
         }
     },
     "externalService": {


### PR DESCRIPTION
Not specifying the filesystem will cause FileSystem.get to return the local filesystem when not called under `hadoop jar` (i.e. in Tomcat).

collectivemedia/tracker#36
@collectivemedia/syn-datapipe2
