### PR TITLE
Celos user completion

### DIFF
--- a/provisioner/roles/yarn/tasks/main.yaml
+++ b/provisioner/roles/yarn/tasks/main.yaml
@@ -48,7 +48,7 @@
   tags: yarn
  
 - name: Create hdfs home dir for celos
-  shell: creates=/usr/lib/hadoop-mapreduce/celos.homedired su -hdfs -c "hadoop fs -mkdir /user/celos  && hadoop fs -chown  celos /user/celos" && touch /usr/lib/hadoop-mapreduce/celos.homedired
+  shell: creates=/usr/lib/hadoop-mapreduce/celos.homedired su - hdfs -c "hadoop fs -mkdir /user/celos  && hadoop fs -chown  celos:mapred /user/celos" && touch /usr/lib/hadoop-mapreduce/celos.homedired
   tags: yarn
 
 - name: set HADOOP_MAPRED_HOME


### PR DESCRIPTION
With Celos user after this commit I tested
- Running an oozie example Map Reduce
- Check it on history server.

We are now able to submit jobs via oozie, access hdfs , run map reduce task as Celos User, which I believe successfully completes our MRV2 migration part .

collectivemedia/tracker#36
@collectivemedia/syn-datapipe2
