### PR TITLE
remove cl from js

### DIFF
--- a/celos-ci/src/main/java/com/collective/celos/ci/mode/TestTask.java
+++ b/celos-ci/src/main/java/com/collective/celos/ci/mode/TestTask.java
@@ -29,10 +29,10 @@ public class TestTask extends CelosCi {
         CelosCiTarget target = parser.parse(commandLine.getTargetUri());
 
         TestConfigurationParser configurationParser = new TestConfigurationParser();
-        configurationParser.evaluateTestConfig(commandLine, configJSFile);
+        configurationParser.evaluateTestConfig(configJSFile);
 
         for (TestCase testCase : configurationParser.getTestCases()) {
-            testRuns.add(new TestRun(target, commandLine.getUserName(), commandLine.getWorkflowName(), commandLine.getDeployDir(), testCase));
+            testRuns.add(new TestRun(target, commandLine, testCase));
         }
     }
 

--- a/celos-ci/src/main/java/com/collective/celos/ci/mode/test/TestConfigurationParser.java
+++ b/celos-ci/src/main/java/com/collective/celos/ci/mode/test/TestConfigurationParser.java
@@ -22,18 +22,16 @@ public class TestConfigurationParser {
     private final List<TestCase> testCases = Lists.newArrayList();
     private final JSConfigParser jsConfigParser = new JSConfigParser();
 
-    public void evaluateTestConfig(CelosCiCommandLine commandLine, File testCaseFile) throws IOException {
-        evaluateTestConfig(commandLine, new FileReader(testCaseFile), testCaseFile.getName());
+    public void evaluateTestConfig(File testCaseFile) throws IOException {
+        evaluateTestConfig(new FileReader(testCaseFile), testCaseFile.getName());
     }
 
-    Object evaluateTestConfig(CelosCiCommandLine commandLine, Reader reader, String desc) throws IOException {
+    Object evaluateTestConfig(Reader reader, String desc) throws IOException {
         Global scope = jsConfigParser.createGlobalScope();
 
         Object wrappedContext = Context.javaToJS(this, scope);
-        Object wrappedCommandLine = Context.javaToJS(commandLine, scope);
         Map jsProperties = Maps.newHashMap();
         jsProperties.put("testConfigurationParser", wrappedContext);
-        jsProperties.put("commandLine", wrappedCommandLine);
         jsConfigParser.putPropertiesInScope(jsProperties, scope);
 
         InputStream scripts = getClass().getResourceAsStream("celos-ci-scripts.js");

--- a/celos-ci/src/main/java/com/collective/celos/ci/mode/test/TestRun.java
+++ b/celos-ci/src/main/java/com/collective/celos/ci/mode/test/TestRun.java
@@ -1,6 +1,7 @@
 package com.collective.celos.ci.mode.test;
 
 import com.collective.celos.Util;
+import com.collective.celos.ci.config.CelosCiCommandLine;
 import com.collective.celos.ci.config.deploy.CelosCiContext;
 import com.collective.celos.ci.config.deploy.CelosCiTarget;
 import com.collective.celos.ci.deploy.HdfsDeployer;
@@ -43,14 +44,16 @@ public class TestRun {
     private final File celosTempDir;
     private final String hdfsPrefix;
     private final TestCase testCase;
+    private final File testCasesDir;
 
-    public TestRun(CelosCiTarget target, String username, String workflowName, File deployDir, TestCase testCase) throws Exception {
+    public TestRun(CelosCiTarget target, CelosCiCommandLine commandLine, TestCase testCase) throws Exception {
 
         this.testCase = testCase;
         this.celosTempDir = Files.createTempDirectory("celos").toFile();
+        this.testCasesDir = commandLine.getTestCasesDir();
 
         String testUUID = UUID.randomUUID().toString();
-        String hdfsPrefix = String.format(HDFS_PREFIX_PATTERN, username, workflowName, testUUID);
+        String hdfsPrefix = String.format(HDFS_PREFIX_PATTERN, commandLine.getUserName(), commandLine.getWorkflowName(), testUUID);
 
         this.hdfsPrefix = Util.requireNonNull(hdfsPrefix);
         this.celosWorkflowDir = new File(celosTempDir, WORKFLOW_DIR_CELOS_PATH);
@@ -58,7 +61,7 @@ public class TestRun {
         this.celosDbDir = new File(celosTempDir, DB_DIR_CELOS_PATH);
 
         CelosCiTarget testTarget = new CelosCiTarget(target.getPathToHdfsSite(), target.getPathToCoreSite(), celosWorkflowDir.toURI(), target.getDefaultsFile());
-        this.ciContext = new CelosCiContext(testTarget, username, CelosCiContext.Mode.TEST, deployDir, workflowName, hdfsPrefix);
+        this.ciContext = new CelosCiContext(testTarget, commandLine.getUserName(), CelosCiContext.Mode.TEST, commandLine.getDeployDir(), commandLine.getWorkflowName(), hdfsPrefix);
 
         this.wfDeployer = new WorkflowFileDeployer(ciContext);
         this.hdfsDeployer = new HdfsDeployer(ciContext);
@@ -78,6 +81,10 @@ public class TestRun {
 
     public File getCelosTempDir() {
         return celosTempDir;
+    }
+
+    public File getTestCasesDir() {
+        return testCasesDir;
     }
 
     public String getHdfsPrefix() {

--- a/celos-ci/src/main/java/com/collective/celos/ci/testing/fixtures/create/FixDirFromResourceCreator.java
+++ b/celos-ci/src/main/java/com/collective/celos/ci/testing/fixtures/create/FixDirFromResourceCreator.java
@@ -15,26 +15,27 @@ import java.util.Map;
  */
 public class FixDirFromResourceCreator implements FixObjectCreator<FixDir> {
 
-    private final File path;
+    private final String relativePath;
 
-    public FixDirFromResourceCreator(File testCasesDir, String path) {
-        this.path = new File(testCasesDir, path);
-    }
-
-    public File getPath() {
-        return path;
+    public FixDirFromResourceCreator(String path) {
+        this.relativePath = path;
     }
 
     public FixDir create(TestRun testRun) throws Exception {
+        File path = getPath(testRun);
         if (!path.isDirectory()) {
             throw new IllegalStateException("Cannot find directory: " + path);
         }
         return read(path).asDir();
     }
 
+    public File getPath(TestRun testRun) {
+        return new File(testRun.getTestCasesDir(), relativePath);
+    }
+
     @Override
     public String getDescription(TestRun testRun) {
-        return path.getAbsolutePath();
+        return getPath(testRun).getAbsolutePath();
     }
 
     private FixObject read(File file) throws Exception {

--- a/celos-ci/src/main/java/com/collective/celos/ci/testing/fixtures/create/FixFileFromResourceCreator.java
+++ b/celos-ci/src/main/java/com/collective/celos/ci/testing/fixtures/create/FixFileFromResourceCreator.java
@@ -1,35 +1,40 @@
 package com.collective.celos.ci.testing.fixtures.create;
 
 import com.collective.celos.ci.mode.test.TestRun;
+import com.collective.celos.ci.testing.structure.fixobject.FixDir;
 import com.collective.celos.ci.testing.structure.fixobject.FixFile;
+import com.collective.celos.ci.testing.structure.fixobject.FixObject;
+import com.google.common.collect.Maps;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Map;
 
 /**
  * Created by akonopko on 10/7/14.
  */
 public class FixFileFromResourceCreator implements FixObjectCreator<FixFile> {
+    private final String relativePath;
 
-    private final File path;
-
-    public FixFileFromResourceCreator(File testCasesDir, String path) {
-        this.path = new File(testCasesDir, path);
+    public FixFileFromResourceCreator(String path) {
+        this.relativePath = path;
     }
 
     public FixFile create(TestRun testRun) throws Exception {
-        if (!path.isFile()) {
-            throw new IllegalStateException("Cannot find file: " + path);
+        File path = getPath(testRun);
+        if (!path.isDirectory()) {
+            throw new IllegalStateException("Cannot find directory: " + path);
         }
         return new FixFile(new FileInputStream(path));
     }
 
-    @Override
-    public String getDescription(TestRun testRun) {
-        return path.getAbsolutePath();
+    public File getPath(TestRun testRun) {
+        return new File(testRun.getTestCasesDir(), relativePath);
     }
 
-    public File getPath() {
-        return path;
+    @Override
+    public String getDescription(TestRun testRun) {
+        return getPath(testRun).getAbsolutePath();
     }
+
 }

--- a/celos-ci/src/main/resources/com/collective/celos/ci/mode/test/celos-ci-scripts.js
+++ b/celos-ci/src/main/resources/com/collective/celos/ci/mode/test/celos-ci-scripts.js
@@ -1,24 +1,24 @@
 importPackage(Packages.com.collective.celos.ci.testing.fixtures.create);
 importPackage(Packages.com.collective.celos.ci.testing.fixtures.deploy);
 importPackage(Packages.com.collective.celos.ci.testing.fixtures.compare);
-importPackage(Packages.com.collective.celos.ci.mode.test);
 importPackage(Packages.com.collective.celos.ci.testing.fixtures.convert.avro);
 importPackage(Packages.com.collective.celos.ci.testing.structure.fixobject);
-importPackage(Packages.java.util);
 importPackage(Packages.com.collective.celos.ci.testing.fixtures.compare.json);
+importPackage(Packages.com.collective.celos.ci.mode.test);
+importPackage(Packages.java.util);
 
 function fixDirFromResource(resource) {
     if (!resource) {
         throw "Undefined resource";
     }
-    return new FixDirFromResourceCreator(commandLine.getTestCasesDir(), resource);
+    return new FixDirFromResourceCreator(resource);
 }
 
 function fixFileFromResource(resource) {
     if (!resource) {
         throw "Undefined resource";
     }
-    return new FixFileFromResourceCreator(commandLine.getTestCasesDir(), resource);
+    return new FixFileFromResourceCreator(resource);
 }
 
 function fixFile(content) {

--- a/celos-ci/src/test/java/com/collective/celos/ci/mode/TestRunTest.java
+++ b/celos-ci/src/test/java/com/collective/celos/ci/mode/TestRunTest.java
@@ -29,7 +29,7 @@ public class TestRunTest {
         CelosCiCommandLine commandLine = new CelosCiCommandLine("", "TEST", "deploydir", "workflow", "testDir", "uname");
         CelosCiTarget target = new CelosCiTarget(hadoopHdfsUrl, hadoopCoreUrl, URI.create("celoswfdir"), URI.create("deffile"));
         TestCase testCase = new TestCase("tc1", "2013-12-20T16:00Z", "2013-12-20T16:00Z");
-        TestRun celosCiTest = new TestRun(target, commandLine.getUserName(), commandLine.getWorkflowName(), commandLine.getDeployDir(), testCase);
+        TestRun celosCiTest = new TestRun(target, commandLine, testCase);
 
         CelosCiContext context = celosCiTest.getCiContext();
 

--- a/celos-ci/src/test/java/com/collective/celos/ci/mode/TestTaskTest.java
+++ b/celos-ci/src/test/java/com/collective/celos/ci/mode/TestTaskTest.java
@@ -4,12 +4,14 @@ import com.collective.celos.ScheduledTime;
 import com.collective.celos.ci.config.CelosCiCommandLine;
 import com.collective.celos.ci.config.deploy.CelosCiTarget;
 import com.collective.celos.ci.config.deploy.CelosCiTargetParser;
+import com.collective.celos.ci.mode.test.TestRun;
 import com.collective.celos.ci.testing.fixtures.compare.RecursiveDirComparer;
 import com.collective.celos.ci.testing.fixtures.create.OutputFixDirFromHdfsCreator;
 import com.collective.celos.ci.testing.fixtures.create.FixDirFromResourceCreator;
 import com.collective.celos.ci.testing.fixtures.deploy.HdfsInputDeployer;
 import junit.framework.Assert;
 import org.apache.hadoop.fs.Path;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -17,10 +19,21 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileOutputStream;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by akonopko on 10/2/14.
  */
 public class TestTaskTest {
+
+    private TestRun testRun;
+
+    @Before
+    public void setUp() {
+        testRun = mock(TestRun.class);
+        doReturn(new File("testDir")).when(testRun).getTestCasesDir();
+    }
 
 
     @Rule
@@ -71,7 +84,7 @@ public class TestTaskTest {
         OutputFixDirFromHdfsCreator hdfsCreator = (OutputFixDirFromHdfsCreator) comparer.getActualDataCreator();
         Assert.assertEquals(hdfsCreator.getPath(), new Path("output/wordcount1"));
         FixDirFromResourceCreator resourceDataCreator = (FixDirFromResourceCreator) comparer.getExpectedDataCreator();
-        Assert.assertEquals(resourceDataCreator.getPath(), new File("testDir/src/test/celos-ci/test-1/output/plain/output/wordcount1"));
+        Assert.assertEquals(resourceDataCreator.getPath(testRun), new File("testDir/src/test/celos-ci/test-1/output/plain/output/wordcount1"));
 
         Assert.assertEquals(testTask.getTestRuns().get(1).getCiContext().getTarget().getDefaultsFile(), target.getDefaultsFile());
         Assert.assertEquals(testTask.getTestRuns().get(1).getCiContext().getTarget().getPathToCoreSite(), target.getPathToCoreSite());
@@ -87,7 +100,7 @@ public class TestTaskTest {
         OutputFixDirFromHdfsCreator hdfsCreator2 = (OutputFixDirFromHdfsCreator) comparer2.getActualDataCreator();
         Assert.assertEquals(hdfsCreator2.getPath(), new Path("output/wordcount2"));
         FixDirFromResourceCreator resourceDataCreator2 = (FixDirFromResourceCreator) comparer2.getExpectedDataCreator();
-        Assert.assertEquals(resourceDataCreator2.getPath(), new File("testDir/src/test/celos-ci/test-1/output/plain/output/wordcount2"));
+        Assert.assertEquals(resourceDataCreator2.getPath(testRun), new File("testDir/src/test/celos-ci/test-1/output/plain/output/wordcount2"));
 
     }
 

--- a/celos-ci/src/test/java/com/collective/celos/ci/testing/fixtures/compare/JsonContentsDirComparerTest.java
+++ b/celos-ci/src/test/java/com/collective/celos/ci/testing/fixtures/compare/JsonContentsDirComparerTest.java
@@ -1,12 +1,14 @@
 package com.collective.celos.ci.testing.fixtures.compare;
 
 import com.collective.celos.ci.Utils;
+import com.collective.celos.ci.mode.test.TestRun;
 import com.collective.celos.ci.testing.fixtures.compare.json.JsonContentsDirComparer;
 import com.collective.celos.ci.testing.fixtures.create.FixDirFromResourceCreator;
 import com.collective.celos.ci.testing.structure.fixobject.FixDir;
 import com.collective.celos.ci.testing.structure.fixobject.FixFile;
 import com.google.common.collect.Sets;
 import junit.framework.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -14,18 +16,28 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Set;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by akonopko on 10/9/14.
  */
 public class JsonContentsDirComparerTest {
 
+    private TestRun testRun;
+
+    @Before
+    public void setUp() {
+        testRun = mock(TestRun.class);
+        doReturn(new File("/")).when(testRun).getTestCasesDir();
+    }
 
     @Test
     public void testJsonContentsDirComparerOK() throws Exception {
 
         File dir1= new File(Thread.currentThread().getContextClassLoader().getResource("com/collective/celos/ci/fixtures/jsoncompare/1").toURI());
-        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(new File("/"), dir1.getAbsolutePath());
-        FixDir fixDir1 = creator.create(null).asDir();
+        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(dir1.getAbsolutePath());
+        FixDir fixDir1 = creator.create(testRun).asDir();
 
         InputStream content = Thread.currentThread().getContextClassLoader().getResourceAsStream("com/collective/celos/ci/fixtures/jsoncompare/2/content");
         JsonContentsDirComparer dirComparer = new JsonContentsDirComparer(Collections.EMPTY_SET, Utils.wrap(new FixFile(content)), Utils.wrap(fixDir1));
@@ -42,8 +54,8 @@ public class JsonContentsDirComparerTest {
 
         File dir1= new File(Thread.currentThread().getContextClassLoader().getResource("com/collective/celos/ci/fixtures/jsoncompare/1").toURI());
 
-        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(new File("/"), dir1.getAbsolutePath());
-        FixDir fixDir1 = creator.create(null).asDir();
+        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(dir1.getAbsolutePath());
+        FixDir fixDir1 = creator.create(testRun).asDir();
         JsonContentsDirComparer dirComparer = new JsonContentsDirComparer(ignorePaths, Utils.wrap(new FixFile(content)), Utils.wrap(fixDir1));
 
         FixObjectCompareResult compareResult = dirComparer.check(null);
@@ -57,8 +69,8 @@ public class JsonContentsDirComparerTest {
 
         File dir1= new File(Thread.currentThread().getContextClassLoader().getResource("com/collective/celos/ci/fixtures/jsoncompare/1").toURI());
 
-        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(new File("/"), dir1.getAbsolutePath());
-        FixDir fixDir1 = creator.create(null).asDir();
+        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(dir1.getAbsolutePath());
+        FixDir fixDir1 = creator.create(testRun).asDir();
         JsonContentsDirComparer dirComparer = new JsonContentsDirComparer(Collections.EMPTY_SET, Utils.wrap(new FixFile(content), "desc1"), Utils.wrap(fixDir1, "desc2"));
 
         FixObjectCompareResult compareResult = dirComparer.check(null);
@@ -76,8 +88,8 @@ public class JsonContentsDirComparerTest {
 
         File dir1= new File(Thread.currentThread().getContextClassLoader().getResource("com/collective/celos/ci/fixtures/jsoncompare/1").toURI());
 
-        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(new File("/"), dir1.getAbsolutePath());
-        FixDir fixDir1 = creator.create(null).asDir();
+        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(dir1.getAbsolutePath());
+        FixDir fixDir1 = creator.create(testRun).asDir();
         JsonContentsDirComparer dirComparer = new JsonContentsDirComparer(Collections.EMPTY_SET, Utils.wrap(new FixFile(is)), Utils.wrap(fixDir1));
 
         FixObjectCompareResult compareResult = dirComparer.check(null);
@@ -97,8 +109,8 @@ public class JsonContentsDirComparerTest {
 
         File dir1= new File(Thread.currentThread().getContextClassLoader().getResource("com/collective/celos/ci/fixtures/jsoncompare/1").toURI());
 
-        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(new File("/"), dir1.getAbsolutePath());
-        FixDir fixDir1 = creator.create(null).asDir();
+        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(dir1.getAbsolutePath());
+        FixDir fixDir1 = creator.create(testRun).asDir();
         JsonContentsDirComparer dirComparer = new JsonContentsDirComparer(Collections.EMPTY_SET, Utils.wrap(new FixFile(is), "desc1"), Utils.wrap(fixDir1, "desc2"));
 
         FixObjectCompareResult compareResult = dirComparer.check(null);

--- a/celos-ci/src/test/java/com/collective/celos/ci/testing/fixtures/create/FileTreeFixObjectCreatorTest.java
+++ b/celos-ci/src/test/java/com/collective/celos/ci/testing/fixtures/create/FileTreeFixObjectCreatorTest.java
@@ -12,15 +12,27 @@ import com.collective.celos.ci.testing.structure.fixobject.FixObject;
 import com.google.common.collect.Maps;
 import junit.framework.Assert;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.util.Map;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 /**
  * Created by akonopko on 10/9/14.
  */
 public class FileTreeFixObjectCreatorTest {
+
+    private TestRun testRun;
+
+    @Before
+    public void setUp() {
+        testRun = mock(TestRun.class);
+        doReturn(new File("/")).when(testRun).getTestCasesDir();
+    }
 
     @Test
     public void testFileTreeFixObjectCreator() throws Exception {
@@ -41,8 +53,8 @@ public class FileTreeFixObjectCreatorTest {
         contentRead.put("dir1", dir1);
         FixDir readDir = new FixDir(contentRead);
 
-        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(new File(""), path);
-        FixObjectCompareResult compareResult = new RecursiveDirComparer(Utils.wrap(readDir), creator).check(null);
+        FixDirFromResourceCreator creator = new FixDirFromResourceCreator(path);
+        FixObjectCompareResult compareResult = new RecursiveDirComparer(Utils.wrap(readDir), creator).check(testRun);
 
         Assert.assertEquals(compareResult.getStatus(), FixObjectCompareResult.Status.SUCCESS);
     }


### PR DESCRIPTION
i noticed that i pass CelosCommandLine to JS context
in order to get testCasesDir from there
refactored code so CelosCommandLine was removed from JS context so now it looks simpler
